### PR TITLE
Fix: Resolve CJK Enhanced UI conflict in Windows nav mode

### DIFF
--- a/addon/globalPlugins/numpadNavMode.py
+++ b/addon/globalPlugins/numpadNavMode.py
@@ -170,6 +170,51 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	#: A dict of user assigned gestures, containing their values in G form
 	userGestures = {}
 
+	#: Gesture mappings used for CJK Enhanced UI compatibility.
+	CJK_COMPAT_GESTURES = (
+		("kb:numpad2", "kb:downarrow"),
+		("kb:shift+numpad2", "kb:shift+downarrow"),
+		("kb:numpad1", "kb:end"),
+		("kb:numpad3", "kb:pagedown"),
+	)
+
+	def _hasCjkAddon(self) -> bool:
+		"""Checks whether CJK Enhanced UI is running."""
+		for addon in addonHandler.getRunningAddons():
+			if addon.name == "CJKEnhancedUI":
+				return True
+		return False
+
+	def _setCjkCompat(self, enable: bool) -> None:
+		"""Applies or removes CJK compatibility gestures."""
+		if not self._hasCjkAddon():
+			log.debug("CJK Enhanced UI not found.")
+			return
+
+		for gesture, script in self.CJK_COMPAT_GESTURES:
+			if enable:
+				manager.userGestureMap.add(
+					gesture,
+					"globalPlugins.cjkEnhancedUI",
+					"GlobalPlugin",
+					script,
+				)
+			else:
+				try:
+					manager.userGestureMap.remove(
+						gesture,
+						"globalPlugins.cjkEnhancedUI",
+						"GlobalPlugin",
+						script,
+					)
+				except ValueError:
+					pass
+
+		if enable:
+			log.debug("Enabled CJK compatibility gestures.")
+		else:
+			log.debug("Disabled CJK compatibility gestures.")
+
 	def __init__(self):
 		"""Initializes the add-on by performing the following tasks:
 		- If the NVDA config is set to enter Windows nav mode on startup, we enter it here.
@@ -331,6 +376,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			manager.userGestureMap.add("kb(laptop):" + gFrag, *action, True)
 			manager.userGestureMap.add("kb:" + gFrag, action.mod, action.cls, None, True)
 
+		self._setCjkCompat(True)
+
 	def _setNVDANavMode(self) -> None:
 		"""A setMode() helper method, to put the numpad back in NVDA mode.
 		Overview: for each numpad gesture, check whether:
@@ -371,6 +418,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			# If the gesture isn't set, we need to put it back.
 			if gest not in currentGestures:
 				manager.userGestureMap.add(gest, *action, True)
+
+		self._setCjkCompat(False)
 
 	def handleConfigProfileSwitch(self):
 		if config.conf["numpadNavMode"]["profilesUseInitialNumlockState"]:


### PR DESCRIPTION
### Summary of the issue
When this add-on is in Windows navigation mode, some numpad keys may stop working right if CJK Enhanced UI is also installed.
This can happen because both add-ons try to use some of the same keys. Then numpad 1, 2, 3, and Shift+numpad2 may stop acting like End, Down Arrow, Page Down, and Shift+Down Arrow.

#### User facing changes
* Added a small fix for CJK Enhanced UI compatibility.
* In Windows navigation mode, the known conflicting numpad keys work as expected.
* When switching back to NVDA navigation mode, the extra mappings are removed.
#### Developer facing changes
* Added a small CJK compatibility mapping list.
* Added a helper to check whether CJK Enhanced UI is running.
* Added a helper to add or remove the compatibility mappings.
#### Development approach
* Added the CJK fix as a small helper.
* Called that helper when entering and leaving Windows navigation mode.
* Left the main mode-switching flow unchanged.
### Testing Steps
1. [Download the numpadNavMode try build](https://github.com/user-attachments/files/26481660/numpadNavMode.try-build-fix-cjk-windows-nav-conflict.nvda-addon.zip)).
2. Install it.
3. [Download the CJK Enhanced UI add-on](https://addonstore.nvaccess.org/?channel=stable&language=en&apiVersion=2025.3.2&addonId=CJKEnhancedUI).
4. Install it.
5. Restart NVDA.
6. Press NVDA+Alt+NumpadPlus to switch to Windows navigation mode.
7. Press Numpad 1, 2, 3, and Shift+Numpad 2.
8. Check that they work like End, Down Arrow, Page Down, and Shift+Down Arrow.
9. Switch back to NVDA navigation mode.
10. Check that the CJK Enhanced UI key bindings work normally again.
### Known issues with pull request:
None.
### Credit
This approach was based on a suggestion from a community developer who gave permission for it to be reused, but asked not to be named. We appreciate their contribution.
